### PR TITLE
Add missing syntax highlighting

### DIFF
--- a/gruvbox-dark.tmTheme
+++ b/gruvbox-dark.tmTheme
@@ -750,7 +750,7 @@
         <key>name</key>
         <string>Entities</string>
         <key>scope</key>
-        <string>entity.name.accessor, entity.name.function, entity.name.label, entity.name.section</string>
+        <string>entity.name, entity.name.accessor, entity.name.function, entity.name.label, entity.name.section</string>
         <key>settings</key>
         <dict>
           <key>foreground</key>


### PR DESCRIPTION
Fixes missing (compared to the Sublime theme version) highlighting for (at least) struct definitions in Rust.
There's also highlighting missing for structs themselves (when they're used), but I haven't yet figured out how to fix that.

Here's an image for details on the problem:
![image](https://i.imgur.com/oweC3F1.png)