### PR TITLE
Added UUID keys to make it compatible with TextMate

### DIFF
--- a/gruvbox (Dark) (Hard) NDC.tmTheme
+++ b/gruvbox (Dark) (Hard) NDC.tmTheme
@@ -1505,5 +1505,7 @@
         </dict>
       </dict>
     </array>
+    <key>uuid</key>
+    <string>7813D551-48C8-484B-AAA2-DD0F818F5B92</string>
   </dict>
 </plist>

--- a/gruvbox (Dark) (Hard).tmTheme
+++ b/gruvbox (Dark) (Hard).tmTheme
@@ -1505,5 +1505,7 @@
         </dict>
       </dict>
     </array>
+    <key>uuid</key>
+    <string>B0F2884B-50D2-49B3-9A33-D27E0FD5B9E9</string>
   </dict>
 </plist>

--- a/gruvbox (Dark) (Medium) NDC.tmTheme
+++ b/gruvbox (Dark) (Medium) NDC.tmTheme
@@ -1505,5 +1505,7 @@
         </dict>
       </dict>
     </array>
+    <key>uuid</key>
+    <string>6C184988-36BC-449D-94AE-4D7AF30FD29E</string>
   </dict>
 </plist>

--- a/gruvbox (Dark) (Medium).tmTheme
+++ b/gruvbox (Dark) (Medium).tmTheme
@@ -1505,5 +1505,7 @@
         </dict>
       </dict>
     </array>
+    <key>uuid</key>
+    <string>09B5368C-CD49-49D2-A097-36AF9E66252D</string>
   </dict>
 </plist>

--- a/gruvbox (Dark) (Soft) NDC.tmTheme
+++ b/gruvbox (Dark) (Soft) NDC.tmTheme
@@ -1505,5 +1505,7 @@
         </dict>
       </dict>
     </array>
+    <key>uuid</key>
+    <string>8CD661DE-B6F7-41AA-B0D4-6009AA2E8035</string>
   </dict>
 </plist>

--- a/gruvbox (Dark) (Soft).tmTheme
+++ b/gruvbox (Dark) (Soft).tmTheme
@@ -1505,5 +1505,7 @@
         </dict>
       </dict>
     </array>
+    <key>uuid</key>
+    <string>C14AA716-B2D7-4C3E-905C-447E0E108CC6</string>
   </dict>
 </plist>

--- a/gruvbox (Light) (Hard) NDC.tmTheme
+++ b/gruvbox (Light) (Hard) NDC.tmTheme
@@ -1505,5 +1505,7 @@
         </dict>
       </dict>
     </array>
+    <key>uuid</key>
+    <string>CC697CF3-D56B-4723-98E4-71BC6FF9FA69</string>
   </dict>
 </plist>

--- a/gruvbox (Light) (Hard).tmTheme
+++ b/gruvbox (Light) (Hard).tmTheme
@@ -1505,5 +1505,7 @@
         </dict>
       </dict>
     </array>
+    <key>uuid</key>
+    <string>71E6A70A-7D0C-44E6-9815-DAE5EAB0EE40</string>
   </dict>
 </plist>

--- a/gruvbox (Light) (Medium) NDC.tmTheme
+++ b/gruvbox (Light) (Medium) NDC.tmTheme
@@ -1505,5 +1505,7 @@
         </dict>
       </dict>
     </array>
+    <key>uuid</key>
+    <string>8388C1CC-7707-4E9A-B165-7B1F3BE1D804</string>
   </dict>
 </plist>

--- a/gruvbox (Light) (Medium).tmTheme
+++ b/gruvbox (Light) (Medium).tmTheme
@@ -1505,5 +1505,7 @@
         </dict>
       </dict>
     </array>
+    <key>uuid</key>
+    <string>B5C689B9-FE13-45E7-B4B0-808BB789A2C5</string>
   </dict>
 </plist>

--- a/gruvbox (Light) (Soft) NDC.tmTheme
+++ b/gruvbox (Light) (Soft) NDC.tmTheme
@@ -1505,5 +1505,7 @@
         </dict>
       </dict>
     </array>
+    <key>uuid</key>
+    <string>3564787B-1399-467B-BC0B-36FBCF5CAA7E</string>
   </dict>
 </plist>

--- a/gruvbox (Light) (Soft).tmTheme
+++ b/gruvbox (Light) (Soft).tmTheme
@@ -1505,5 +1505,7 @@
         </dict>
       </dict>
     </array>
+    <key>uuid</key>
+    <string>D7A14929-1C8D-4711-9546-23F7E8C14100</string>
   </dict>
 </plist>


### PR DESCRIPTION
This pull request inserts an individual UUID key/value into each theme. This update makes the themes compatible with TextMate while being ignored by Sublime Text.

Rationale:

I tried to install these themes into TextMate and got the following error:

> The bundle item “gruvbox (Light) (Soft)” could not be installed because it is malformed. The bundle item lacks mandatory keys in its property list file.

This happens because the original .tmTheme format requires an individual UUID key/value pair which is missing in these files. Its inclusion doesn’t cause any adverse effect in Sublime Text while making it compatible with TextMate. As this format was originally borrowed from TextMate, please consider accepting the pull request so we can all enjoy them. :)